### PR TITLE
Fix Next link to use next.name instead of previous.name

### DIFF
--- a/src/PokemonPage.jsx
+++ b/src/PokemonPage.jsx
@@ -32,7 +32,7 @@ const PokemonPage = ({ previous, next }) => {
       <div className="links">
         {previous && <Link to={`/pokemon/${previous.name}`}>Previous</Link>}
         <Link to="/">Home</Link>
-        {next && <Link to={`/pokemon/${previous.name}`}>Next</Link>}
+        {next && <Link to={`/pokemon/${next.name}`}>Next</Link>}
       </div>
       <div className={`pokemon-page pokemon-type-${type.name}`}>
         <div className="pokemon-image" style={{ backgroundImage: `url(${pokemon.sprites.front_default})` }} />


### PR DESCRIPTION
This pull request fixes a bug in the PokemonPage component where the "Next" link was incorrectly pointing to the previous Pokemon.